### PR TITLE
split usage: --mail-from and --pgp-mail-from

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,5 +24,6 @@ This worker listens to AMQP-based queue and does a delivery synchronization with
 - *PGP\_CHECK* - Enable (`True`) or Disable (`False`) PGP private key check, default: `True`
 - *PGP\_PRIVATE\_KEY\_PASSWORD* - credentials for *PGP/GPG* private key. Used for encryption or signing.
 - *PGP\_PRIVATE\_KEY\_FILE* - path to *PGP/GPG* private key *on local filesystem*. **Should contain both private and public part.**
+- *PGP\_MAIL\_FROM* - address (may be with skipped domain) to search encryption key (i.e. used as *KEY\_ID* in *PGP\_PRIVATE\_KEY\_FILE*)
 - *DELIVERY\_DESTINATIONS\_FILE* - path for *delivery\_destinations.yml* settings file. See format below.
 

--- a/oc_ftp_upload_worker/ClientDeliverySender.py
+++ b/oc_ftp_upload_worker/ClientDeliverySender.py
@@ -308,7 +308,7 @@ class KeyValidation(object):
     """
     Validates the private key's passphrase
     """
-    def __init__(self, key_path, passphrase, mail_from, mail_domain):
+    def __init__(self, key_path, passphrase, pgp_mail_from, mail_domain):
         """"
         Reads private key used to sign delivery
         :param key_path: private key path on local filesystem
@@ -324,7 +324,7 @@ class KeyValidation(object):
             raise EnvironmentSetupError(f"Private key not found: [{key_path}]")
 
         private_key = read_key(fs.osfs.OSFS(os.path.abspath(os.path.sep)), key_path)
-        _validate_private_keys([private_key], passphrase, mail_from, mail_domain)
+        _validate_private_keys([private_key], passphrase, pgp_mail_from, mail_domain)
 
 
 ConnectionsContext = namedtuple("ConnectionsContext",
@@ -361,7 +361,7 @@ def _validate_keys(keys):
         _get_initialized_gpg(temp_fs, keys)
 
 
-def _validate_private_keys(keys, passphrase, mail_from, mail_domain):
+def _validate_private_keys(keys, passphrase, pgp_mail_from, mail_domain):
     """
     Checks that the passphrase is correct
     """
@@ -369,10 +369,10 @@ def _validate_private_keys(keys, passphrase, mail_from, mail_domain):
         gpg = _get_initialized_gpg(temp_fs, keys, passphrase=passphrase)
         message = "Encryption test"
 
-        if '@' not in mail_from:
-            mail_from = '@'.join([mail_from, mail_domain])
+        if '@' not in pgp_mail_from:
+            pgp_mail_from = '@'.join([pgp_mail_from, mail_domain])
 
-        encrypted = gpg.encrypt(message, mail_from, always_trust=True)
+        encrypted = gpg.encrypt(message, pgp_mail_from, always_trust=True)
         encrypted_string = str(encrypted)
         decrypted = gpg.decrypt(encrypted_string, passphrase=passphrase)
         if not decrypted.ok:

--- a/oc_ftp_upload_worker/ftp_connect.py
+++ b/oc_ftp_upload_worker/ftp_connect.py
@@ -161,7 +161,7 @@ if __name__ == "__main__":
                         default=os.getenv("MAIL_DOMAIN") or "example.com")
     parser.add_argument("--mail-from", dest="mail_from", 
                         help="Mail user to be set as the notification sender in FROM section",
-                        default=os.getenv("MAIL_FROM") or os.getenv("SMTP_USER") or "support")
+                        default=os.getenv("MAIL_FROM") or os.getenv("SMTP_USER"))
     parser.add_argument("--mail-config-file", dest="mail_config_file", help="Mailer configuration file",
                         default=os.path.abspath(os.getenv("MAIL_CONFIG_FILE") or 
                             pkg_resources.resource_filename("oc_ftp_upload_worker", 
@@ -174,6 +174,9 @@ if __name__ == "__main__":
     parser.add_argument("--pgp-private-key-password", dest="pgp_private_key_password", 
                         help="Password for PGP private key",
                         default=os.getenv("PGP_PRIVATE_KEY_PASSWORD"))
+    parser.add_argument("--pgp-mail-from", dest="pgp_mail_from", 
+                        help="Mail user to be set as the notification sender in FROM section",
+                        default=os.getenv('PGP_MAIL_FROM') or os.getenv("MAIL_FROM") or os.getenv("SMTP_USER"))
 
 
     args = parser.parse_args()
@@ -187,7 +190,9 @@ if __name__ == "__main__":
             "mvn_int_url": "mvn_url",
             "mvn_int_user": "mvn_user",
             "mvn_int_password": "mvn_password",
-            "mvn_link_url": ["mvn_ext_url", "mvn_url"]}
+            "mvn_link_url": ["mvn_ext_url", "mvn_url"],
+            "mail_from": ["smtp_user"],
+            "pgp_mail_from": ["mail_from", "smtp_user"]}
 
     for _k, _v in __override.items():
 

--- a/oc_ftp_upload_worker/upload_worker.py
+++ b/oc_ftp_upload_worker/upload_worker.py
@@ -31,7 +31,9 @@ class UploadWorkerApplication(UploadWorkerServer):
                 "mvn_int_url": "mvn_url",
                 "mvn_int_user": "mvn_user",
                 "mvn_int_password": "mvn_password",
-                "mvn_link_url": ["mvn_ext_url", "mvn_url"]}
+                "mvn_link_url": ["mvn_ext_url", "mvn_url"],
+                "mail_from": ["smtp_user"],
+                "pgp_mail_from": ["mail_from", "smtp_user"]}
 
         for _k, _v in __override.items():
 
@@ -79,7 +81,7 @@ class UploadWorkerApplication(UploadWorkerServer):
             logging.info("Validating private key's passphrase")
             from .ClientDeliverySender import KeyValidation
             KeyValidation(args.pgp_private_key_file, args.pgp_private_key_password,
-                    args.mail_from, args.mail_domain)
+                    args.pgp_mail_from, args.mail_domain)
 
         if not self.setup_orm:
             return
@@ -225,7 +227,7 @@ class UploadWorkerApplication(UploadWorkerServer):
                             default=os.getenv("MAIL_DOMAIN") or "example.com")
         parser.add_argument("--mail-from", dest="mail_from", 
                             help="Mail user to be set as the notification sender in FROM section",
-                            default=os.getenv("MAIL_FROM") or os.getenv("SMTP_USER") or "support")
+                            default=os.getenv("MAIL_FROM") or os.getenv("SMTP_USER"))
         parser.add_argument("--mail-config-file", dest="mail_config_file", help="Mailer configuration file",
                             default=os.path.abspath(os.getenv("MAIL_CONFIG_FILE") or \
                                 pkg_resources.resource_filename(
@@ -238,6 +240,9 @@ class UploadWorkerApplication(UploadWorkerServer):
                             default=os.path.abspath(os.getenv("PGP_PRIVATE_KEY_FILE") or os.path.join(os.getcwd(), "private_key.asc")))
         parser.add_argument("--pgp-private-key-password", dest="pgp_private_key_password", help="Password for PGP private key",
                             default=os.getenv("PGP_PRIVATE_KEY_PASSWORD"))
+        parser.add_argument("--pgp-mail-from", dest="pgp_mail_from",
+                            help="Mail user to be set as the notification sender in FROM section",
+                            default=os.getenv('PGP_MAIL_FROM') or os.getenv("MAIL_FROM") or os.getenv("SMTP_USER"))
 
         return parser
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 import os
 import glob
 
-__version = '1.12.0'
+__version = '1.13.0'
 
 def list_recursive(app, directory, extension="*"):
     dir_to_walk = os.path.join(app, directory)


### PR DESCRIPTION
-  split usage `--mail-from` and `--pgp-mail-from`: new argument added
- overrides for mail arguments added
- default value `support` for `mail_from` is deprecated: replaced with `smtp_user`